### PR TITLE
Update TJCOverallFHIR.cql

### DIFF
--- a/input/cql/TJCOverallFHIR.cql
+++ b/input/cql/TJCOverallFHIR.cql
@@ -67,8 +67,8 @@ define "Ischemic Stroke Encounters with Discharge Disposition":
 
 define "Comfort Measures during Hospitalization":
   "Ischemic Stroke Encounter" IschemicStrokeEncounter
-       	//with "Intervention Comfort Measures" ComfortMeasure
-        //	such that FHIRHelpers.ToDateTime(Coalesce(ComfortMeasure.performed as dateTime,ComfortMeasure.authoredOn)) during Global."HospitalizationWithObservation"(IschemicStrokeEncounter)
+       	with "Intervention Comfort Measures" ComfortMeasure
+        such that FHIRHelpers.ToDateTime(Coalesce(ComfortMeasure.performed as dateTime,ComfortMeasure.authoredOn)) during Global."HospitalizationWithObservation"(IschemicStrokeEncounter)
 
 define "Encounter with Principal Diagnosis and Age":
   "All Stroke Encounter" AllStrokeEncounter


### PR DESCRIPTION
Removed '// ' from definition of "Comfort Measures during Hospitalization", where it causes incorrect testing result