### PR TITLE
Added negative testcases to falsify Initial population

### DIFF
--- a/input/tests/library/CervicalCancerScreeningFHIR/neg-denom-EXM124/Encounter/neg-denom-EXM124-1.json
+++ b/input/tests/library/CervicalCancerScreeningFHIR/neg-denom-EXM124/Encounter/neg-denom-EXM124-1.json
@@ -1,0 +1,33 @@
+{
+    "resourceType": "Encounter",
+    "id": "neg-denom-EXM124-1",
+    "subject": {
+        "reference": "Patient/neg-denom-EXM124"
+    },
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+        ]
+    },
+    "status": "finished",
+    "class": {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        "code": "AMB",
+        "display": "ambulatory"
+    },
+    "type": [
+        {
+            "coding": [
+                {
+                    "system": "http://www.ama-assn.org/go/cpt",
+                    "code": "99201",
+                    "display": "Office or other outpatient visit for the evaluation and management of a new patient, which requires these 3 key components: A problem focused history; A problem focused examination; Straightforward medical decision making. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are self limited or minor. Typically, 10 minutes are spent face-to-face with the patient and/or family."
+                }
+            ]
+        }
+    ],
+    "period": {
+        "start": "2019-01-01T01:00:00.0",
+        "end": "2019-01-02T01:00:00.0"
+    }
+}

--- a/input/tests/library/CervicalCancerScreeningFHIR/neg-denom-EXM124/Observation/neg-denom-EXM124-2.json
+++ b/input/tests/library/CervicalCancerScreeningFHIR/neg-denom-EXM124/Observation/neg-denom-EXM124-2.json
@@ -1,0 +1,23 @@
+{
+    "resourceType": "Observation",
+    "id": "neg-denom-EXM124-2",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/observation"
+        ]
+      },
+    "status": "final",
+    "code": {
+        "coding": [
+            {
+                "system": "http://loinc.org",
+                "code": "10524-7",
+                "display": "Microscopic observation [Identifier] in Cervix by Cyto stain"
+            }
+        ]
+    },
+    "subject": {
+        "reference": "Patient/neg-denom-EXM124"
+    },
+    "effectiveDateTime": "2019-11-01T00:00:00"
+}

--- a/input/tests/library/CervicalCancerScreeningFHIR/neg-denom-EXM124/Patient/neg-denom-EXM124.json
+++ b/input/tests/library/CervicalCancerScreeningFHIR/neg-denom-EXM124/Patient/neg-denom-EXM124.json
@@ -1,0 +1,63 @@
+{
+  "resourceType": "Patient",
+  "id": "neg-denom-EXM124",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+    ]
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2028-9",
+            "display": "Asian"
+          }
+        }
+      ]
+    },
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2135-2",
+            "display": "Hispanic or Latino"
+          }
+        }
+      ]
+    }
+  ],
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MR",
+            "display": "Medical Record Number"
+          }
+        ]
+      },
+      "system": "http://hospital.smarthealthit.org",
+      "value": "999999995"
+    }
+  ],
+  "name": [
+    {
+      "family": "Bertha",
+      "given": [
+        "Betty"
+      ]
+    }
+  ],
+  "birthDate": "1999-01-01",
+  "gender": "male"
+}

--- a/input/tests/library/CervicalCancerScreeningFHIR/neg-numer-EXM124/Encounter/neg-numer-EXM124-1.json
+++ b/input/tests/library/CervicalCancerScreeningFHIR/neg-numer-EXM124/Encounter/neg-numer-EXM124-1.json
@@ -1,0 +1,33 @@
+{
+  "resourceType": "Encounter",
+  "id": "neg-numer-EXM124-1",
+  "subject": {
+    "reference": "Patient/neg-numer-EXM124"
+  },
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+    ]
+  },
+  "status": "finished",
+  "class": {
+    "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+    "code": "AMB",
+    "display": "ambulatory"
+  },
+  "type": [
+    {
+      "coding": [
+        {
+          "system": "http://www.ama-assn.org/go/cpt",
+          "code": "99201",
+          "display": "Office or other outpatient visit for the evaluation and management of a new patient, which requires these 3 key components: A problem focused history; A problem focused examination; Straightforward medical decision making. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are self limited or minor. Typically, 10 minutes are spent face-to-face with the patient and/or family."
+        }
+      ]
+    }
+  ],
+  "period": {
+      "start": "2019-01-01T00:00:00.0",
+      "end": "2019-01-02T00:00:00.0"
+  }
+}

--- a/input/tests/library/CervicalCancerScreeningFHIR/neg-numer-EXM124/Observation/neg-numer-EXM124-2.json
+++ b/input/tests/library/CervicalCancerScreeningFHIR/neg-numer-EXM124/Observation/neg-numer-EXM124-2.json
@@ -1,0 +1,24 @@
+{
+  "resourceType": "Observation",
+  "id": "neg-numer-EXM124-2",
+  "meta": {
+    "profile": [
+        "http://hl7.org/fhir/observation"
+    ]
+  },
+  "status": "final",
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "10524-7",
+        "display": "Microscopic observation [Identifier] in Cervix by Cyto stain"
+      }
+    ]
+  },
+  "valueBoolean": "true",
+  "subject": {
+    "reference": "Patient/neg-numer-EXM124"
+  },
+  "effectiveDateTime": "2019-11-01T00:00:00"
+}

--- a/input/tests/library/CervicalCancerScreeningFHIR/neg-numer-EXM124/Patient/neg-numer-EXM124.json
+++ b/input/tests/library/CervicalCancerScreeningFHIR/neg-numer-EXM124/Patient/neg-numer-EXM124.json
@@ -1,0 +1,63 @@
+{
+  "resourceType": "Patient",
+  "id": "neg-numer-EXM124",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+    ]
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2028-9",
+            "display": "Asian"
+          }
+        }
+      ]
+    },
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2135-2",
+            "display": "Hispanic or Latino"
+          }
+        }
+      ]
+    }
+  ],
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MR",
+            "display": "Medical Record Number"
+          }
+        ]
+      },
+      "system": "http://hospital.smarthealthit.org",
+      "value": "999999995"
+    }
+  ],
+  "name": [
+    {
+      "family": "Brigand",
+      "given": [
+        "Melanie"
+      ]
+    }
+  ],
+  "birthDate": "1999-01-01",
+  "gender": "male"
+}

--- a/input/tests/measure/BreastCancerScreeningFHIR/neg-denom-EXM125/Encounter/neg-denom-EXM125-1.json
+++ b/input/tests/measure/BreastCancerScreeningFHIR/neg-denom-EXM125/Encounter/neg-denom-EXM125-1.json
@@ -1,0 +1,33 @@
+{
+    "resourceType": "Encounter",
+    "id": "neg-denom-EXM125-1",
+    "subject": {
+        "reference": "Patient/neg-denom-EXM125"
+    },
+    "meta": {
+        "profile": [
+          "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+        ]
+      },
+      "status": "finished",
+      "class": {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        "code": "AMB",
+        "display": "ambulatory"
+      },
+    "type": [
+        {
+            "coding": [
+                {
+                    "system": "http://www.ama-assn.org/go/cpt",
+                    "code": "99201",
+                    "display": "Office or other outpatient visit for the evaluation and management of a new patient, which requires these 3 key components: A problem focused history; A problem focused examination; Straightforward medical decision making. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are self limited or minor. Typically, 10 minutes are spent face-to-face with the patient and/or family."
+                }
+            ]
+        }
+    ],
+    "period": {
+        "start": "2018-01-16T08:30:00",
+        "end": "2018-01-20T08:30:00"
+    }
+}

--- a/input/tests/measure/BreastCancerScreeningFHIR/neg-denom-EXM125/Patient/neg-denom-EXM125.json
+++ b/input/tests/measure/BreastCancerScreeningFHIR/neg-denom-EXM125/Patient/neg-denom-EXM125.json
@@ -1,0 +1,63 @@
+{
+  "resourceType": "Patient",
+  "id": "neg-denom-EXM125",
+  "meta": {
+      "profile": [
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+      ]
+    },
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+        "extension": [
+          {
+            "url": "ombCategory",
+            "valueCoding": {
+              "system": "urn:oid:2.16.840.1.113883.6.238",
+              "code": "2106-3",
+              "display": "White"
+            }
+          }
+        ]
+      },
+      {
+        "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+        "extension": [
+          {
+            "url": "ombCategory",
+            "valueCoding": {
+              "system": "urn:oid:2.16.840.1.113883.6.238",
+              "code": "2186-5",
+              "display": "Not Hispanic or Latino"
+            }
+          }
+        ]
+      }
+    ],
+    "identifier": [
+      {
+        "use": "usual",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+              "code": "MR",
+              "display": "Medical Record Number"
+            }
+          ]
+        },
+        "system": "http://hospital.smarthealthit.org",
+        "value": "999999995"
+      }
+    ],
+    "name": [
+      {
+        "family": "Dunn",
+        "given": [
+          "June"
+        ]
+      }
+    ],
+  "birthDate": "1975-01-01",
+  "gender": "male"
+}

--- a/input/tests/measure/CMS111/neg-measure-strat1-EXM111/Encounter/neg-measure-strat1-EXM111-Enc-Admit.json
+++ b/input/tests/measure/CMS111/neg-measure-strat1-EXM111/Encounter/neg-measure-strat1-EXM111-Enc-Admit.json
@@ -1,0 +1,43 @@
+{
+  "resourceType": "Encounter",
+  "id": "neg-measure-strat1-EXM111-Enc-Admit",
+  "subject": {
+      "reference": "Patient/neg-measure-strat1-EXM111"
+  },
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+    ]
+  },
+  "status": "finished",
+  "class": {
+    "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+    "code": "IMP",
+    "display": "inpatient encounter"
+  },
+  "type": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "183452005",
+          "display": "Emergency Hospital Admission (procedure)"
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "reference": "Location/neg-measure-strat1-EXM111-Location",
+      "status": "completed",
+      "period": {
+          "start": "2019-06-15T05:00:00-00:00",
+          "end":   "2019-06-15T10:00:00-00:00"
+      }
+    }
+  ],
+  "period": {
+      "start": "2018-06-15T10:00:00-00:00",
+      "end":   "2019-06-17T10:00:00-00:00"
+  }
+}

--- a/input/tests/measure/CMS111/neg-measure-strat1-EXM111/Encounter/neg-measure-strat1-EXM111-Enc-EDVisit.json
+++ b/input/tests/measure/CMS111/neg-measure-strat1-EXM111/Encounter/neg-measure-strat1-EXM111-Enc-EDVisit.json
@@ -1,0 +1,40 @@
+{
+  "resourceType": "Encounter",
+  "id": "neg-measure-strat1-EXM111-Enc-EDVisit",
+  "subject": {
+      "reference": "Patient/neg-measure-strat1-EXM111"
+  },
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+    ]
+  },
+  "status": "finished",
+  "type": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "4525004",
+          "display": "Emergency department patient visit (procedure)"
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "location": {
+        "reference": "Location/neg-measure-strat1-EXM111-Location"
+      },
+      "status": "completed",
+      "period": {
+          "start": "2018-06-15T05:00:00-00:00",
+          "end":   "2019-06-15T09:30:00-00:00"
+      }
+    }
+  ],
+  "period": {
+      "start": "2019-06-15T05:00:00-00:00",
+      "end":   "2019-06-15T09:45:00-00:00"
+  }
+}

--- a/input/tests/measure/CMS111/neg-measure-strat1-EXM111/Location/neg-measure-strat1-EXM111-Location.json
+++ b/input/tests/measure/CMS111/neg-measure-strat1-EXM111/Location/neg-measure-strat1-EXM111-Location.json
@@ -1,0 +1,16 @@
+{
+  "resourceType": "Location",
+  "id": "neg-measure-strat1-EXM111-Location",
+  "status": "active",
+  "name": "Our Lady of Perpetual Guilt",
+  "type": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "4525004",
+        "display": "Emergency department patient visit (procedure)"
+      }
+    ]
+  }
+
+}

--- a/input/tests/measure/CMS111/neg-measure-strat1-EXM111/Observation/neg-measure-strat1-EXM111-Observation.json
+++ b/input/tests/measure/CMS111/neg-measure-strat1-EXM111/Observation/neg-measure-strat1-EXM111-Observation.json
@@ -1,0 +1,38 @@
+{
+    "resourceType": "Observation",
+    "id": "neg-measure-strat1-EXM111-observation",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/observation"
+        ]
+      },
+    "status": "final",
+    "code": {
+     "coding": [
+       {
+         "system": "http://loinc.org",
+         "code": "28568-4",
+         "display": "Physician Emergency Department Note"
+       }
+     ]
+    },
+    "valueCodeableConcept": {
+     "coding": [
+       {
+         "system": "http://snomed.info/sct",
+         "code": "183767005",
+         "display": "Listed for admission to hospital (finding)"
+       }
+     ]
+    },
+    "encounter": {
+      "reference": "Encounter/neg-measure-strat1-EXM111-Enc-EDVisit"
+    },
+    "subject": {
+        "reference": "Patient/neg-measure-strat1-EXM111"
+    },
+    "effectivePeriod": {
+        "start": "2019-06-15T07:00:00-00:00",
+        "end":   "2019-06-15T07:15:00-00:00"
+    }
+}

--- a/input/tests/measure/CMS111/neg-measure-strat1-EXM111/Patient/neg-measure-strat1-EXM111.json
+++ b/input/tests/measure/CMS111/neg-measure-strat1-EXM111/Patient/neg-measure-strat1-EXM111.json
@@ -1,0 +1,63 @@
+{
+  "resourceType": "Patient",
+  "id": "neg-measure-strat1-EXM111",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+    ]
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2106-3",
+            "display": "White"
+          }
+        }
+      ]
+    },
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2186-5",
+            "display": "Not Hispanic or Latino"
+          }
+        }
+      ]
+    }
+  ],
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MR",
+            "display": "Medical Record Number"
+          }
+        ]
+      },
+      "system": "http://hospital.smarthealthit.org",
+      "value": "9999999911"
+    }
+  ],
+  "name": [
+    {
+      "family": "Abigail",
+      "given": [
+        "Andersen"
+      ]
+    }
+  ],
+  "gender": "female",
+  "birthDate": "1960-08-28"
+}

--- a/input/tests/measure/CMS111/neg-measure-strat1-EXM111/ServiceRequest/neg-measure-strat1-EXM111-ServiceRequest.json
+++ b/input/tests/measure/CMS111/neg-measure-strat1-EXM111/ServiceRequest/neg-measure-strat1-EXM111-ServiceRequest.json
@@ -1,0 +1,22 @@
+{
+  "resourceType": "ServiceRequest",
+  "id": "neg-measure-strat1-EXM111-ServiceRequest",
+  "status": "active",
+  "intent": "order",
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "10378005",
+        "display": "Hospital admisison,  emergency, from emergency room, accidental injury (procedure)"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/neg-measure-strat1-EXM111"
+  },
+  "encounter": {
+    "reference": "Encounter/neg-measure-strat1-EXM111-Enc-EDVisit"
+  },
+  "authoredOn": "2019-06-15T09:10:00-00:00"
+}

--- a/input/tests/measure/CMS111/neg-measure-strat1-excl-EXM111/Encounter/measure-strat1-excl-EXM111-Enc-EDVisit.json
+++ b/input/tests/measure/CMS111/neg-measure-strat1-excl-EXM111/Encounter/measure-strat1-excl-EXM111-Enc-EDVisit.json
@@ -1,0 +1,51 @@
+{
+  "resourceType": "Encounter",
+  "id": "measure-strat1-excl-EXM111-Enc-EDVisit",
+  "subject": {
+      "reference": "Patient/measure-strat1-excl-EXM111"
+  },
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+    ]
+  },
+  "status": "finished",
+  "type": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "4525004",
+          "display": "Emergency department patient visit (procedure)"
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "location": {
+        "reference": "Location/measure-strat1-excl-EXM111-Location"
+      },
+      "status": "completed",
+      "period": {
+          "start": "2019-06-15T05:00:00-00:00",
+          "end":   "2019-06-15T09:30:00-00:00"
+      }
+    }
+  ],
+  "hospitalization": {
+   "admitSource": {
+     "coding": [
+       {
+         "system": "http://snomed.info/sct",
+         "code": "69362002",
+         "display": "Hospital -based ambulatory Surgical facility (environment)"
+       }
+     ]
+   }
+ },
+  "period": {
+      "start": "2019-06-15T05:00:00-00:00",
+      "end":   "2019-06-15T09:45:00-00:00"
+  }
+}

--- a/input/tests/measure/CMS111/neg-measure-strat1-excl-EXM111/Encounter/neg-measure-strat1-excl-EXM111-Enc-Admit.json
+++ b/input/tests/measure/CMS111/neg-measure-strat1-excl-EXM111/Encounter/neg-measure-strat1-excl-EXM111-Enc-Admit.json
@@ -1,0 +1,43 @@
+{
+  "resourceType": "Encounter",
+  "id": "neg-measure-strat1-excl-EXM111-Enc-Admit",
+  "subject": {
+      "reference": "Patient/neg-measure-strat1-excl-EXM111"
+  },
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+    ]
+  },
+  "status": "finished",
+  "class": {
+    "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+    "code": "IMP",
+    "display": "inpatient encounter"
+  },
+  "type": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "183452005",
+          "display": "Emergency Hospital Admission (procedure)"
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "reference": "Location/neg-measure-strat1-excl-EXM111-Location",
+      "status": "completed",
+      "period": {
+          "start": "2019-06-15T05:00:00-00:00",
+          "end":   "2019-06-15T10:00:00-00:00"
+      }
+    }
+  ],
+  "period": {
+      "start": "2018-06-15T10:00:00-00:00",
+      "end":   "2019-06-17T10:00:00-00:00"
+  }
+}

--- a/input/tests/measure/CMS111/neg-measure-strat1-excl-EXM111/Location/neg-measure-strat1-excl-EXM111-Location.json
+++ b/input/tests/measure/CMS111/neg-measure-strat1-excl-EXM111/Location/neg-measure-strat1-excl-EXM111-Location.json
@@ -1,0 +1,16 @@
+{
+  "resourceType": "Location",
+  "id": "neg-measure-strat1-excl-EXM111-Location",
+  "status": "active",
+  "name": "St. Dougs EmUrgency Care",
+  "type": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "4525004",
+        "display": "Emergency department patient visit (procedure)"
+      }
+    ]
+  }
+
+}

--- a/input/tests/measure/CMS111/neg-measure-strat1-excl-EXM111/Observation/neg-measure-strat1-EXM111-Observation.json
+++ b/input/tests/measure/CMS111/neg-measure-strat1-excl-EXM111/Observation/neg-measure-strat1-EXM111-Observation.json
@@ -1,0 +1,38 @@
+{
+    "resourceType": "Observation",
+    "id": "neg-measure-strat1-excl-EXM111-observation",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/observation"
+        ]
+      },
+    "status": "final",
+    "code": {
+     "coding": [
+       {
+         "system": "http://loinc.org",
+         "code": "28568-4",
+         "display": "Physician Emergency Department Note"
+       }
+     ]
+    },
+    "valueCodeableConcept": {
+     "coding": [
+       {
+         "system": "http://snomed.info/sct",
+         "code": "183767005",
+         "display": "Listed for admission to hospital (finding)"
+       }
+     ]
+    },
+    "encounter": {
+      "reference": "Encounter/neg-measure-strat1-excl-EXM111-Enc-EDVisit"
+    },
+    "subject": {
+        "reference": "Patient/neg-measure-strat1-excl-EXM111"
+    },
+    "effectivePeriod": {
+        "start": "2019-06-15T07:00:00-00:00",
+        "end":   "2019-06-15T07:15:00-00:00"
+    }
+}

--- a/input/tests/measure/CMS111/neg-measure-strat1-excl-EXM111/Patient/neg-measure-strat1-excl-EXM111.json
+++ b/input/tests/measure/CMS111/neg-measure-strat1-excl-EXM111/Patient/neg-measure-strat1-excl-EXM111.json
@@ -1,0 +1,63 @@
+{
+  "resourceType": "Patient",
+  "id": "neg-measure-strat1-excl-EXM111",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+    ]
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2106-3",
+            "display": "White"
+          }
+        }
+      ]
+    },
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2186-5",
+            "display": "Not Hispanic or Latino"
+          }
+        }
+      ]
+    }
+  ],
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MR",
+            "display": "Medical Record Number"
+          }
+        ]
+      },
+      "system": "http://hospital.smarthealthit.org",
+      "value": "9999999922"
+    }
+  ],
+  "name": [
+    {
+      "family": "Barbara",
+      "given": [
+        "Broward"
+      ]
+    }
+  ],
+  "gender": "female",
+  "birthDate": "1960-08-28"
+}

--- a/input/tests/measure/CMS111/neg-measure-strat1-excl-EXM111/ServiceRequest/neg-measure-strat1-excl-EXM111-ServiceRequest.json
+++ b/input/tests/measure/CMS111/neg-measure-strat1-excl-EXM111/ServiceRequest/neg-measure-strat1-excl-EXM111-ServiceRequest.json
@@ -1,0 +1,22 @@
+{
+  "resourceType": "ServiceRequest",
+  "id": "neg-measure-strat1-excl-EXM111-ServiceRequest",
+  "status": "active",
+  "intent": "order",
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "10378005",
+        "display": "Hospital admisison,  emergency, from emergency room, accidental injury (procedure)"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/neg-measure-strat1-excl-EXM111"
+  },
+  "encounter": {
+    "reference": "Encounter/neg-measure-strat1-excl-EXM111-Enc-EDVisit"
+  },
+  "authoredOn": "2019-06-15T09:10:00-00:00"
+}

--- a/input/tests/measure/CMS111/neg-measure-strat2-EXM111/Condition/neg-measure-strat2-EXM111-Condition.json
+++ b/input/tests/measure/CMS111/neg-measure-strat2-EXM111/Condition/neg-measure-strat2-EXM111-Condition.json
@@ -1,0 +1,44 @@
+{
+  "resourceType": "Condition",
+  "id": "neg-measure-strat2-EXM111-condition",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+    ]
+  },
+  "verificationStatus": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+        "code": "confirmed",
+        "display": "Confirmed"
+      }
+    ]
+  },
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+          "code": "encounter-diagnosis",
+          "display": "Encounter Diagnosis"
+        }
+      ]
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "111475002",
+        "display": "Neurosis (disorder)"
+      }
+    ]
+  },
+  "encounter": {
+    "reference": "Encounter/neg-measure-strat2-EXM111-Enc-Admit"
+  },
+  "subject": {
+    "reference": "Patient/neg-measure-strat2-EXM111"
+  }
+}

--- a/input/tests/measure/CMS111/neg-measure-strat2-EXM111/Encounter/neg-measure-strat2-EXM111-Enc-Admit.json
+++ b/input/tests/measure/CMS111/neg-measure-strat2-EXM111/Encounter/neg-measure-strat2-EXM111-Enc-Admit.json
@@ -1,0 +1,60 @@
+{
+  "resourceType": "Encounter",
+  "id": "neg-measure-strat2-EXM111-Enc-Admit",
+  "subject": {
+      "reference": "Patient/neg-measure-strat2-EXM111"
+  },
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+    ]
+  },
+  "status": "finished",
+  "class": {
+    "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+    "code": "IMP",
+    "display": "inpatient encounter"
+  },
+  "type": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "183452005",
+          "display": "Emergency Hospital Admission (procedure)"
+        }
+      ]
+    }
+  ],
+  "diagnosis": [
+    {
+      "condition": {
+        "reference": "Condition/neg-measure-strat2-EXM111-condition"
+      },
+      "use": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/diagnosis-role",
+            "code": "AD",
+            "display": "Admission diagnosis"
+          }
+        ]
+      },
+      "rank": 1
+    }
+  ],
+  "location": [
+    {
+      "reference": "Location/neg-measure-strat2-EXM111-Location",
+      "status": "completed",
+      "period": {
+          "start": "2018-03-15T05:00:00-00:00",
+          "end":   "2019-03-15T10:00:00-00:00"
+      }
+    }
+  ],
+  "period": {
+      "start": "2018-03-15T10:00:00-00:00",
+      "end":   "2019-03-17T10:00:00-00:00"
+  }
+}

--- a/input/tests/measure/CMS111/neg-measure-strat2-EXM111/Encounter/neg-measure-strat2-EXM111-Enc-EDVisit.json
+++ b/input/tests/measure/CMS111/neg-measure-strat2-EXM111/Encounter/neg-measure-strat2-EXM111-Enc-EDVisit.json
@@ -1,0 +1,41 @@
+{
+  "resourceType": "Encounter",
+  "id": "neg-measure-strat2-EXM111-Enc-EDVisit",
+  "subject": {
+      "reference": "Patient/neg-measure-strat2-EXM111"
+  },
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+    ]
+  },
+  "status": "finished",
+  "type": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "4525004",
+          "display": "Emergency department patient visit (procedure)"
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "location": {
+        "reference": "Location/neg-measure-strat2-EXM111-Location"
+      },
+      "status": "completed",
+      "period": {
+          "start": "2019-03-15T05:00:00-00:00",
+          "end":   "2019-03-15T09:30:00-00:00"
+      }
+    }
+  ],
+
+  "period": {
+      "start": "2018-03-15T05:00:00-00:00",
+      "end":   "2019-03-15T09:45:00-00:00"
+  }
+}

--- a/input/tests/measure/CMS111/neg-measure-strat2-EXM111/Location/neg-measure-strat2-EXM111-Location.json
+++ b/input/tests/measure/CMS111/neg-measure-strat2-EXM111/Location/neg-measure-strat2-EXM111-Location.json
@@ -1,0 +1,16 @@
+{
+  "resourceType": "Location",
+  "id": "neg-measure-strat2-EXM111-Location",
+  "status": "active",
+  "name": "Sam Chindi's House of Shamans",
+  "type": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "4525004",
+        "display": "Emergency department patient visit (procedure)"
+      }
+    ]
+  }
+
+}

--- a/input/tests/measure/CMS111/neg-measure-strat2-EXM111/Observation/neg-measure-strat2-EXM111-Observation.json
+++ b/input/tests/measure/CMS111/neg-measure-strat2-EXM111/Observation/neg-measure-strat2-EXM111-Observation.json
@@ -1,0 +1,38 @@
+{
+    "resourceType": "Observation",
+    "id": "neg-measure-strat2-EXM111-observation",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/observation"
+        ]
+      },
+    "status": "final",
+    "code": {
+     "coding": [
+       {
+         "system": "http://loinc.org",
+         "code": "78307-6",
+         "display": "Physician Emergency Department Note"
+       }
+     ]
+    },
+    "valueCodeableConcept": {
+     "coding": [
+       {
+         "system": "http://snomed.info/sct",
+         "code": "183783005",
+         "display": "Listed for admission to hospital (finding)"
+       }
+     ]
+    },
+    "encounter": {
+      "reference": "Encounter/neg-measure-strat2-EXM111-Enc-EDVisit"
+    },
+    "subject": {
+        "reference": "Patient/neg-measure-strat2-EXM111"
+    },
+    "effectivePeriod": {
+        "start": "2019-03-15T07:00:00-00:00",
+        "end":   "2019-03-15T07:15:00-00:00"
+    }
+}

--- a/input/tests/measure/CMS111/neg-measure-strat2-EXM111/Patient/neg-measure-strat2-EXM111.json
+++ b/input/tests/measure/CMS111/neg-measure-strat2-EXM111/Patient/neg-measure-strat2-EXM111.json
@@ -1,0 +1,63 @@
+{
+  "resourceType": "Patient",
+  "id": "neg-measure-strat2-EXM111",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+    ]
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2106-3",
+            "display": "White"
+          }
+        }
+      ]
+    },
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2186-5",
+            "display": "Not Hispanic or Latino"
+          }
+        }
+      ]
+    }
+  ],
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MR",
+            "display": "Medical Record Number"
+          }
+        ]
+      },
+      "system": "http://hospital.smarthealthit.org",
+      "value": "9999999933"
+    }
+  ],
+  "name": [
+    {
+      "family": "Charles",
+      "given": [
+        "Crowfoot"
+      ]
+    }
+  ],
+  "gender": "male",
+  "birthDate": "1943-11-13"
+}

--- a/input/tests/measure/CMS111/neg-measure-strat2-EXM111/ServiceRequest/neg-measure-strat2-EXM111-ServiceRequest.json
+++ b/input/tests/measure/CMS111/neg-measure-strat2-EXM111/ServiceRequest/neg-measure-strat2-EXM111-ServiceRequest.json
@@ -1,0 +1,22 @@
+{
+  "resourceType": "ServiceRequest",
+  "id": "neg-measure-strat2-EXM111-ServiceRequest",
+  "status": "active",
+  "intent": "order",
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "10378005",
+        "display": "Hospital admisison,  emergency, from emergency room, accidental injury (procedure)"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/neg-measure-strat2-EXM111"
+  },
+  "encounter": {
+    "reference": "Encounter/neg-measure-strat2-EXM111-Enc-EDVisit"
+  },
+  "authoredOn": "2019-03-15T09:10:00-00:00"
+}

--- a/input/tests/measure/CMS111/neg-measure-strat2-excl-EXM111/Condition/neg-measure-strat2-excl-EXM111-Condition.json
+++ b/input/tests/measure/CMS111/neg-measure-strat2-excl-EXM111/Condition/neg-measure-strat2-excl-EXM111-Condition.json
@@ -1,0 +1,44 @@
+{
+  "resourceType": "Condition",
+  "id": "neg-measure-strat2-excl-EXM111-condition",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+    ]
+  },
+  "verificationStatus": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+        "code": "confirmed",
+        "display": "Confirmed"
+      }
+    ]
+  },
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+          "code": "encounter-diagnosis",
+          "display": "Encounter Diagnosis"
+        }
+      ]
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "111475002",
+        "display": "Neurosis (disorder)"
+      }
+    ]
+  },
+  "encounter": {
+    "reference": "Encounter/neg-measure-strat2-excl-EXM111-Enc-Admit"
+  },
+  "subject": {
+    "reference": "Patient/neg-measure-strat2-excl-EXM111"
+  }
+}

--- a/input/tests/measure/CMS111/neg-measure-strat2-excl-EXM111/Encounter/neg-measure-strat2-excl-EXM111-Enc-Admit.json
+++ b/input/tests/measure/CMS111/neg-measure-strat2-excl-EXM111/Encounter/neg-measure-strat2-excl-EXM111-Enc-Admit.json
@@ -1,0 +1,60 @@
+{
+  "resourceType": "Encounter",
+  "id": "neg-measure-strat2-excl-EXM111-Enc-Admit",
+  "subject": {
+      "reference": "Patient/neg-measure-strat2-excl-EXM111"
+  },
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+    ]
+  },
+  "status": "finished",
+  "class": {
+    "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+    "code": "IMP",
+    "display": "inpatient encounter"
+  },
+  "type": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "183452005",
+          "display": "Emergency Hospital Admission (procedure)"
+        }
+      ]
+    }
+  ],
+  "diagnosis": [
+    {
+      "condition": {
+        "reference": "Condition/neg-measure-strat2-excl-EXM111-condition"
+      },
+      "use": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/diagnosis-role",
+            "code": "AD",
+            "display": "Admission diagnosis"
+          }
+        ]
+      },
+      "rank": 1
+    }
+  ],
+  "location": [
+    {
+      "reference": "Location/neg-measure-strat2-excl-EXM111-Location",
+      "status": "completed",
+      "period": {
+          "start": "2019-03-15T05:00:00-00:00",
+          "end":   "2019-03-15T10:00:00-00:00"
+      }
+    }
+  ],
+  "period": {
+      "start": "2018-03-15T10:00:00-00:00",
+      "end":   "2019-03-17T10:00:00-00:00"
+  }
+}

--- a/input/tests/measure/CMS111/neg-measure-strat2-excl-EXM111/Encounter/neg-measure-strat2-excl-EXM111-Enc-EDVisit.json
+++ b/input/tests/measure/CMS111/neg-measure-strat2-excl-EXM111/Encounter/neg-measure-strat2-excl-EXM111-Enc-EDVisit.json
@@ -1,0 +1,51 @@
+{
+  "resourceType": "Encounter",
+  "id": "neg-measure-strat2-excl-EXM111-Enc-EDVisit",
+  "subject": {
+      "reference": "Patient/neg-measure-strat2-excl-EXM111"
+  },
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+    ]
+  },
+  "status": "finished",
+  "type": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "4525004",
+          "display": "neg-Emergency department patient visit (procedure)"
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "location": {
+        "reference": "Location/neg-measure-strat2-excl-EXM111-Location"
+      },
+      "status": "completed",
+      "period": {
+          "start": "2019-03-15T05:00:00-00:00",
+          "end":   "2019-03-15T09:30:00-00:00"
+      }
+    }
+  ],
+  "hospitalization": {
+    "admitSource": {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "73770003",
+          "display": "Hospital-based outpatient emergency care center (environment)"
+        }
+      ]
+    }
+  },
+  "period": {
+      "start": "2018-03-15T05:00:00-00:00",
+      "end":   "2019-03-15T09:45:00-00:00"
+  }
+}

--- a/input/tests/measure/CMS111/neg-measure-strat2-excl-EXM111/Location/neg-measure-strat2-excl-EXM111-Location.json
+++ b/input/tests/measure/CMS111/neg-measure-strat2-excl-EXM111/Location/neg-measure-strat2-excl-EXM111-Location.json
@@ -1,0 +1,16 @@
+{
+  "resourceType": "Location",
+  "id": "neg-measure-strat2-excl-EXM111-Location",
+  "status": "active",
+  "name": "DeChelley Spider Woman Clinic",
+  "type": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "4525004",
+        "display": "Emergency department patient visit (procedure)"
+      }
+    ]
+  }
+
+}

--- a/input/tests/measure/CMS111/neg-measure-strat2-excl-EXM111/Observation/neg-measure-strat2-excl-EXM111-Observation.json
+++ b/input/tests/measure/CMS111/neg-measure-strat2-excl-EXM111/Observation/neg-measure-strat2-excl-EXM111-Observation.json
@@ -1,0 +1,38 @@
+{
+    "resourceType": "Observation",
+    "id": "neg-measure-strat2-excl-EXM111-observation",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/observation"
+        ]
+      },
+    "status": "final",
+    "code": {
+     "coding": [
+       {
+         "system": "http://loinc.org",
+         "code": "78307-6",
+         "display": "Physician Emergency Department Note"
+       }
+     ]
+    },
+    "valueCodeableConcept": {
+     "coding": [
+       {
+         "system": "http://snomed.info/sct",
+         "code": "183783005",
+         "display": "Listed for admission to hospital (finding)"
+       }
+     ]
+    },
+    "encounter": {
+      "reference": "Encounter/neg-measure-strat2-excl-EXM111-Enc-EDVisit"
+    },
+    "subject": {
+        "reference": "Patient/neg-measure-strat2-excl-EXM111"
+    },
+    "effectivePeriod": {
+        "start": "2019-03-15T07:00:00-00:00",
+        "end":   "2019-03-15T07:15:00-00:00"
+    }
+}

--- a/input/tests/measure/CMS111/neg-measure-strat2-excl-EXM111/Patient/neg-measure-strat2-excl-EXM111.json
+++ b/input/tests/measure/CMS111/neg-measure-strat2-excl-EXM111/Patient/neg-measure-strat2-excl-EXM111.json
@@ -1,0 +1,63 @@
+{
+  "resourceType": "Patient",
+  "id": "neg-measure-strat2-excl-EXM111",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+    ]
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2106-3",
+            "display": "White"
+          }
+        }
+      ]
+    },
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2186-5",
+            "display": "Not Hispanic or Latino"
+          }
+        }
+      ]
+    }
+  ],
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MR",
+            "display": "Medical Record Number"
+          }
+        ]
+      },
+      "system": "http://hospital.smarthealthit.org",
+      "value": "9999999944"
+    }
+  ],
+  "name": [
+    {
+      "family": "David",
+      "given": [
+        "Darkhorse"
+      ]
+    }
+  ],
+  "gender": "male",
+  "birthDate": "1943-11-13"
+}

--- a/input/tests/measure/CMS111/neg-measure-strat2-excl-EXM111/ServiceRequest/measure-strat2-excl-EXM111-ServiceRequest.json
+++ b/input/tests/measure/CMS111/neg-measure-strat2-excl-EXM111/ServiceRequest/measure-strat2-excl-EXM111-ServiceRequest.json
@@ -1,0 +1,22 @@
+{
+  "resourceType": "ServiceRequest",
+  "id": "neg-measure-strat2-excl-EXM111-ServiceRequest",
+  "status": "active",
+  "intent": "order",
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "10378005",
+        "display": "Hospital admisison,  emergency, from emergency room, accidental injury (procedure)"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/neg-measure-strat2-excl-EXM111"
+  },
+  "encounter": {
+    "reference": "Encounter/neg-measure-strat2-excl-EXM111-Enc-EDVisit"
+  },
+  "authoredOn": "2019-03-15T09:10:00-00:00"
+}

--- a/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-denom-EXM153/Condition/neg-denom-EXM153-Condition.json
+++ b/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-denom-EXM153/Condition/neg-denom-EXM153-Condition.json
@@ -1,0 +1,42 @@
+{
+  "resourceType": "Condition",
+  "id": "neg-denom-EXM153-Condition",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+    ]
+  },
+  "verificationStatus": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/condition-verification",
+        "code": "confirmed"
+      }
+    ]
+  },
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+          "code": "encounter-diagnosis",
+          "display": "Encounter Diagnosis"
+        }
+      ]
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "129670002",
+        "display": "Herpetic cervicitis (disorder)"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/neg-denom-EXM153"
+  },
+  "onsetDateTime": "2019-02-21",
+  "abatementDateTime": "2019-02-22"
+}

--- a/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-denom-EXM153/Encounter/neg-denom-EXM153-Encounter.json
+++ b/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-denom-EXM153/Encounter/neg-denom-EXM153-Encounter.json
@@ -1,0 +1,33 @@
+{
+  "resourceType": "Encounter",
+  "id": "neg-denom-EXM153-Encounter",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+    ]
+  },
+  "status": "finished",
+  "class": {
+    "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+    "code": "IMP",
+    "display": "inpatient encounter"
+  },
+  "type": [
+    {
+      "coding": [
+        {
+          "system": "http://www.ama-assn.org/go/cpt",
+          "code": "99385",
+          "display": "Initial comprehensive preventive medicine evaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, new patient; 18-39 years"
+        }
+      ]
+    }
+  ],
+  "subject": {
+    "reference": "Patient/neg-denom-EXM153"
+  },
+  "period": {
+    "start": "2019-08-21T08:00:00-07:00",
+    "end": "2019-08-21T08:15:00-07:00"
+  }
+}

--- a/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-denom-EXM153/Patient/neg-denom-EXM153.json
+++ b/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-denom-EXM153/Patient/neg-denom-EXM153.json
@@ -1,0 +1,63 @@
+{
+  "resourceType": "Patient",
+  "id": "neg-denom-EXM153",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+    ]
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2106-3",
+            "display": "White"
+          }
+        }
+      ]
+    },
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2186-5",
+            "display": "Not Hispanic or Latino"
+          }
+        }
+      ]
+    }
+  ],
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MR",
+            "display": "Medical Record Number"
+          }
+        ]
+      },
+      "system": "http://hospital.smarthealthit.org",
+      "value": "9999999911"
+    }
+  ],
+  "name": [
+    {
+      "family": "Jones",
+      "given": [
+        "Louise"
+      ]
+    }
+  ],
+  "gender": "male",
+  "birthDate": "2002-01-21"
+}

--- a/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-denomexcl-153/Encounter/neg-denom-EXM153-Encounter.json
+++ b/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-denomexcl-153/Encounter/neg-denom-EXM153-Encounter.json
@@ -1,0 +1,33 @@
+{
+  "resourceType": "Encounter",
+  "id": "neg-denomexcl-EXM153-Encounter",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+    ]
+  },
+  "status": "finished",
+  "class": {
+    "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+    "code": "IMP",
+    "display": "inpatient encounter"
+  },
+  "type": [
+    {
+      "coding": [
+        {
+          "system": "http://www.ama-assn.org/go/cpt",
+          "code": "99385",
+          "display": "Initial comprehensive preventive medicine evaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, new patient; 18-39 years"
+        }
+      ]
+    }
+  ],
+  "subject": {
+    "reference": "Patient/neg-denomexcl-EXM153"
+  },
+  "period": {
+    "start": "2019-08-21T08:00:00-07:00",
+    "end": "2019-08-21T08:15:00-07:00"
+  }
+}

--- a/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-denomexcl-153/Patient/neg-denom-EXM153.json
+++ b/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-denomexcl-153/Patient/neg-denom-EXM153.json
@@ -1,0 +1,63 @@
+{
+  "resourceType": "Patient",
+  "id": "neg-denomexcl-EXM153",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+    ]
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2106-3",
+            "display": "White"
+          }
+        }
+      ]
+    },
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2186-5",
+            "display": "Not Hispanic or Latino"
+          }
+        }
+      ]
+    }
+  ],
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MR",
+            "display": "Medical Record Number"
+          }
+        ]
+      },
+      "system": "http://hospital.smarthealthit.org",
+      "value": "9999999911"
+    }
+  ],
+  "name": [
+    {
+      "family": "Jones",
+      "given": [
+        "Louise"
+      ]
+    }
+  ],
+  "gender": "female",
+  "birthDate": "2010-01-21"
+}

--- a/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-denomexcl-153/ServiceRequest/denomexcl-EXM153-ServiceRequest-Pregnancy.json
+++ b/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-denomexcl-153/ServiceRequest/denomexcl-EXM153-ServiceRequest-Pregnancy.json
@@ -1,0 +1,22 @@
+{
+  "resourceType": "ServiceRequest",
+  "id": "denomexcl-EXM153-ServiceRequest-Pregnancy",
+  "status": "active",
+  "intent": "order",
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "19080-1",
+        "display": "Choriogonadotropin [Units/volume] in Serum or Plasma"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/neg-denomexcl-EXM153"
+  },
+  "encounter": {
+    "reference": "Encounter/neg-denomexcl-EXM153-Encounter"
+  },
+  "authoredOn": "2019-08-21T00:00:00-06:00"
+}

--- a/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-denomexcl-153/ServiceRequest/denomexcl-EXM153-ServiceRequest-XRay.json
+++ b/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-denomexcl-153/ServiceRequest/denomexcl-EXM153-ServiceRequest-XRay.json
@@ -1,0 +1,22 @@
+{
+  "resourceType": "ServiceRequest",
+  "id": "denomexcl-EXM153-ServiceRequest-XRay",
+  "status": "active",
+  "intent": "order",
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "24532-4",
+        "display": "US Abdomen RUQ"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/neg-denomexcl-EXM153"
+  },
+  "encounter": {
+    "reference": "Encounter/neg-denomexcl-EXM153-Encounter"
+  },
+  "authoredOn": "2019-08-24T00:00:00-06:00"
+}

--- a/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-numer-strat1-EXM153/Condition/neg-numer-strat1-EXM153-Condition.json
+++ b/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-numer-strat1-EXM153/Condition/neg-numer-strat1-EXM153-Condition.json
@@ -1,0 +1,42 @@
+{
+  "resourceType": "Condition",
+  "id": "neg-numer-strat1-EXM153-Condition",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+    ]
+  },
+  "verificationStatus": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/condition-verification",
+        "code": "confirmed"
+      }
+    ]
+  },
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+          "code": "encounter-diagnosis",
+          "display": "Encounter Diagnosis"
+        }
+      ]
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "129670002",
+        "display": "Herpetic cervicitis (disorder)"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/neg-numer-strat1-EXM153"
+  },
+  "onsetDateTime": "2019-02-21",
+  "abatementDateTime": "2019-02-22"
+}

--- a/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-numer-strat1-EXM153/Encounter/neg-numer-strat1-EXM153-Encounter.json
+++ b/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-numer-strat1-EXM153/Encounter/neg-numer-strat1-EXM153-Encounter.json
@@ -1,0 +1,33 @@
+{
+  "resourceType": "Encounter",
+  "id": "neg-numer-strat1-EXM153-Encounter",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+    ]
+  },
+  "status": "finished",
+  "class": {
+    "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+    "code": "IMP",
+    "display": "inpatient encounter"
+  },
+  "type": [
+    {
+      "coding": [
+        {
+          "system": "http://www.ama-assn.org/go/cpt",
+          "code": "99385",
+          "display": "Initial comprehensive preventive medicine evaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, new patient; 18-39 years"
+        }
+      ]
+    }
+  ],
+  "subject": {
+    "reference": "Patient/neg-numer-strat1-EXM153"
+  },
+  "period": {
+    "start": "2019-08-21T08:00:00-07:00",
+    "end": "2019-08-21T08:15:00-07:00"
+  }
+}

--- a/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-numer-strat1-EXM153/Observation/neg-numer-strat1-EXM153-Observation.json
+++ b/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-numer-strat1-EXM153/Observation/neg-numer-strat1-EXM153-Observation.json
@@ -1,0 +1,24 @@
+{
+  "resourceType": "Observation",
+  "id": "neg-numer-strat1-EXM153-Observation",
+  "meta": {
+    "profile": [
+        "http://hl7.org/fhir/observation"
+    ]
+  },
+  "status": "final",
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "14463-4",
+        "display": "Chlamydia trachomatis [Presence] in Cervix by Organism specific culture"
+      }
+    ]
+  },
+  "valueBoolean": "true",
+  "subject": {
+    "reference": "Patient/neg-numer-strat1-EXM153"
+  },
+  "effectiveDateTime": "2019-11-01T00:00:00"
+}

--- a/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-numer-strat1-EXM153/Patient/neg-numer-strat1-EXM153.json
+++ b/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-numer-strat1-EXM153/Patient/neg-numer-strat1-EXM153.json
@@ -1,0 +1,63 @@
+{
+  "resourceType": "Patient",
+  "id": "neg-numer-strat1-EXM153",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+    ]
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2106-3",
+            "display": "White"
+          }
+        }
+      ]
+    },
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2186-5",
+            "display": "Not Hispanic or Latino"
+          }
+        }
+      ]
+    }
+  ],
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MR",
+            "display": "Medical Record Number"
+          }
+        ]
+      },
+      "system": "http://hospital.smarthealthit.org",
+      "value": "9999999911"
+    }
+  ],
+  "name": [
+    {
+      "family": "Jones",
+      "given": [
+        "Louise"
+      ]
+    }
+  ],
+  "gender": "male",
+  "birthDate": "2010-01-21"
+}

--- a/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-numer-strat2-EXM153/Condition/neg-numer-strat2-EXM153-Condition.json
+++ b/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-numer-strat2-EXM153/Condition/neg-numer-strat2-EXM153-Condition.json
@@ -1,0 +1,42 @@
+{
+  "resourceType": "Condition",
+  "id": "neg-numer-strat2-EXM153-Condition",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+    ]
+  },
+  "verificationStatus": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/condition-verification",
+        "code": "confirmed"
+      }
+    ]
+  },
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+          "code": "encounter-diagnosis",
+          "display": "Encounter Diagnosis"
+        }
+      ]
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "129670002",
+        "display": "Herpetic cervicitis (disorder)"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/neg-numer-strat2-EXM153"
+  },
+  "onsetDateTime": "2019-02-21",
+  "abatementDateTime": "2019-02-22"
+}

--- a/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-numer-strat2-EXM153/Encounter/neg-numer-strat2-EXM153-Encounter.json
+++ b/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-numer-strat2-EXM153/Encounter/neg-numer-strat2-EXM153-Encounter.json
@@ -1,0 +1,33 @@
+{
+  "resourceType": "Encounter",
+  "id": "neg-numer-strat2-EXM153-Encounter",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+    ]
+  },
+  "status": "finished",
+  "class": {
+    "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+    "code": "IMP",
+    "display": "inpatient encounter"
+  },
+  "type": [
+    {
+      "coding": [
+        {
+          "system": "http://www.ama-assn.org/go/cpt",
+          "code": "99385",
+          "display": "Initial comprehensive preventive medicine evaluation and management of an individual including an age and gender appropriate history, examination, counseling/anticipatory guidance/risk factor reduction interventions, and the ordering of laboratory/diagnostic procedures, new patient; 18-39 years"
+        }
+      ]
+    }
+  ],
+  "subject": {
+    "reference": "Patient/neg-numer-strat2-EXM153"
+  },
+  "period": {
+    "start": "2019-08-21T08:00:00-07:00",
+    "end": "2019-08-21T08:15:00-07:00"
+  }
+}

--- a/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-numer-strat2-EXM153/Observation/neg-numer-strat2-EXM153-Observation.json
+++ b/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-numer-strat2-EXM153/Observation/neg-numer-strat2-EXM153-Observation.json
@@ -1,0 +1,24 @@
+{
+  "resourceType": "Observation",
+  "id": "neg-numer-strat2-EXM153-Observation",
+  "meta": {
+    "profile": [
+        "http://hl7.org/fhir/observation"
+    ]
+  },
+  "status": "final",
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "14463-4",
+        "display": "Chlamydia trachomatis [Presence] in Cervix by Organism specific culture"
+      }
+    ]
+  },
+  "valueBoolean": "true",
+  "subject": {
+    "reference": "Patient/neg-numer-strat2-EXM153"
+  },
+  "effectiveDateTime": "2019-11-01T00:00:00"
+}

--- a/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-numer-strat2-EXM153/Patient/neg-numer-strat2-EXM153.json
+++ b/input/tests/measure/ChlamydiaScreeningforWomenFHIR/neg-numer-strat2-EXM153/Patient/neg-numer-strat2-EXM153.json
@@ -1,0 +1,63 @@
+{
+  "resourceType": "Patient",
+  "id": "neg-numer-strat2-EXM153",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+    ]
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2106-3",
+            "display": "White"
+          }
+        }
+      ]
+    },
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2186-5",
+            "display": "Not Hispanic or Latino"
+          }
+        }
+      ]
+    }
+  ],
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MR",
+            "display": "Medical Record Number"
+          }
+        ]
+      },
+      "system": "http://hospital.smarthealthit.org",
+      "value": "9999999911"
+    }
+  ],
+  "name": [
+    {
+      "family": "Jones",
+      "given": [
+        "Louise"
+      ]
+    }
+  ],
+  "gender": "female",
+  "birthDate": "2011-01-21"
+}

--- a/input/tests/measure/ColorectalCancerScreeningsFHIR/neg-denom-EXM130/Encounter/neg-denom-EXM130-1.json
+++ b/input/tests/measure/ColorectalCancerScreeningsFHIR/neg-denom-EXM130/Encounter/neg-denom-EXM130-1.json
@@ -1,0 +1,33 @@
+{
+  "resourceType": "Encounter",
+  "id": "neg-denom-EXM130-1",
+  "subject": {
+      "reference": "Patient/neg-denom-EXM130"
+  },
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+    ]
+  },
+  "status": "finished",
+  "class": {
+    "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+    "code": "AMB",
+    "display": "ambulatory"
+  },
+  "type": [
+      {
+          "coding": [
+              {
+                  "system": "http://www.ama-assn.org/go/cpt",
+                  "code": "99201",
+                  "display": "Office or other outpatient visit for the evaluation and management of a new patient, which requires these 3 key components: A problem focused history; A problem focused examination; Straightforward medical decision making. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are self limited or minor. Typically, 10 minutes are spent face-to-face with the patient and/or family."
+              }
+          ]
+      }
+  ],
+  "period": {
+      "start": "2019-05-30T00:00:00-00:00",
+      "end": "2019-05-31T00:00:00-00:00"
+  }
+}

--- a/input/tests/measure/ColorectalCancerScreeningsFHIR/neg-denom-EXM130/Patient/neg-denom-EXM130.json
+++ b/input/tests/measure/ColorectalCancerScreeningsFHIR/neg-denom-EXM130/Patient/neg-denom-EXM130.json
@@ -1,0 +1,63 @@
+{
+  "resourceType": "Patient",
+  "id": "neg-denom-EXM130",
+  "meta": {
+      "profile": [
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+      ]
+    },
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+        "extension": [
+          {
+            "url": "ombCategory",
+            "valueCoding": {
+              "system": "urn:oid:2.16.840.1.113883.6.238",
+              "code": "2028-9",
+              "display": "Asian"
+            }
+          }
+        ]
+      },
+      {
+        "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+        "extension": [
+          {
+            "url": "ombCategory",
+            "valueCoding": {
+              "system": "urn:oid:2.16.840.1.113883.6.238",
+              "code": "2135-2",
+              "display": "Hispanic or Latino"
+            }
+          }
+        ]
+      }
+    ],
+    "identifier": [
+      {
+        "use": "usual",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+              "code": "MR",
+              "display": "Medical Record Number"
+            }
+          ]
+        },
+        "system": "http://hospital.smarthealthit.org",
+        "value": "999999992"
+      }
+    ],
+    "name": [
+      {
+        "family": "Dere",
+        "given": [
+          "Ben"
+        ]
+      }
+    ],
+    "birthDate": "1975-01-01",
+    "gender": "male"
+  }

--- a/input/tests/measure/ColorectalCancerScreeningsFHIR/neg-denom-EXM130/Procedure/neg-denom-EXM130-2.json
+++ b/input/tests/measure/ColorectalCancerScreeningsFHIR/neg-denom-EXM130/Procedure/neg-denom-EXM130-2.json
@@ -1,0 +1,26 @@
+{
+    "resourceType": "Procedure",
+    "id": "neg-denom-EXM130-2",
+    "meta": {
+        "profile": [
+          "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
+        ]
+    },
+    "status": "completed",
+    "code": {
+        "coding": [
+            {
+                "system": "http://www.ama-assn.org/go/cpt",
+                "code": "44393",
+                "display": "Colonoscopy through stoma; with ablation of tumor(s), polyp(s), or other lesion(s) not amenable to removal by hot biopsy forceps, bipolar cautery or snare technique"
+            }
+        ]
+    },
+    "subject": {
+        "reference": "Patient/neg-denom-EXM130"
+    },
+    "performedPeriod": {
+        "start": "2009-12-30T12:00:00",
+        "end": "2009-12-30T13:00:00"
+    }
+}

--- a/input/tests/measure/ColorectalCancerScreeningsFHIR/neg-numer-EXM130/Encounter/neg-numer-EXM130-4.json
+++ b/input/tests/measure/ColorectalCancerScreeningsFHIR/neg-numer-EXM130/Encounter/neg-numer-EXM130-4.json
@@ -1,0 +1,33 @@
+{
+    "resourceType": "Encounter",
+    "id": "neg-numer-EXM130-4",
+    "subject": {
+        "reference": "Patient/neg-numer-EXM130"
+    },
+    "meta": {
+        "profile": [
+          "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+        ]
+      },
+      "status": "finished",
+      "class": {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+        "code": "AMB",
+        "display": "ambulatory"
+      },
+    "type": [
+        {
+            "coding": [
+                {
+                    "system": "http://www.ama-assn.org/go/cpt",
+                    "code": "99201",
+                    "display": "Office or other outpatient visit for the evaluation and management of a new patient, which requires these 3 key components: A problem focused history; A problem focused examination; Straightforward medical decision making. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are self limited or minor. Typically, 10 minutes are spent face-to-face with the patient and/or family."
+                }
+            ]
+        }
+    ],
+    "period": {
+        "start": "2019-05-30T00:00:00.0",
+        "end": "2019-05-31T00:00:00.0"
+    }
+}

--- a/input/tests/measure/ColorectalCancerScreeningsFHIR/neg-numer-EXM130/Patient/neg-numer-EXM130.json
+++ b/input/tests/measure/ColorectalCancerScreeningsFHIR/neg-numer-EXM130/Patient/neg-numer-EXM130.json
@@ -1,0 +1,63 @@
+{
+  "resourceType": "Patient",
+  "id": "neg-numer-EXM130",
+  "meta": {
+      "profile": [
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+      ]
+    },
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+        "extension": [
+          {
+            "url": "ombCategory",
+            "valueCoding": {
+              "system": "urn:oid:2.16.840.1.113883.6.238",
+              "code": "2028-9",
+              "display": "Asian"
+            }
+          }
+        ]
+      },
+      {
+        "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+        "extension": [
+          {
+            "url": "ombCategory",
+            "valueCoding": {
+              "system": "urn:oid:2.16.840.1.113883.6.238",
+              "code": "2135-2",
+              "display": "Hispanic or Latino"
+            }
+          }
+        ]
+      }
+    ],
+    "identifier": [
+      {
+        "use": "usual",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+              "code": "MR",
+              "display": "Medical Record Number"
+            }
+          ]
+        },
+        "system": "http://hospital.smarthealthit.org",
+        "value": "999999992"
+      }
+    ],
+    "name": [
+      {
+        "family": "Blitz",
+        "given": [
+          "Don"
+        ]
+      }
+    ],
+  "birthDate": "1975-01-01",
+  "gender": "male"
+}

--- a/input/tests/measure/ColorectalCancerScreeningsFHIR/neg-numer-EXM130/Procedure/neg-numer-EXM130-1.json
+++ b/input/tests/measure/ColorectalCancerScreeningsFHIR/neg-numer-EXM130/Procedure/neg-numer-EXM130-1.json
@@ -1,0 +1,26 @@
+{
+  "resourceType": "Procedure",
+  "id": "neg-numer-EXM130-1",
+  "meta": {
+      "profile": [
+        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
+      ]
+  },
+  "status": "completed",
+  "code": {
+      "coding": [
+          {
+              "system": "http://www.ama-assn.org/go/cpt",
+              "code": "44388",
+              "display": "Colonoscopy through stoma; with ablation of tumor(s), polyp(s), or other lesion(s) not amenable to removal by hot biopsy forceps, bipolar cautery or snare technique"
+          }
+      ]
+  },
+  "subject": {
+      "reference": "Patient/neg-numer-EXM130"
+  },
+  "performedPeriod": {
+      "start": "2010-01-01T00:00:00-06:00",
+      "end": "2010-01-01T01:00:00-07:00"
+  }
+}

--- a/input/tests/measure/ControllingHighBloodPressureFHIR/neg-denom-EXM165-Patient/Condition/neg-denom-condition.json
+++ b/input/tests/measure/ControllingHighBloodPressureFHIR/neg-denom-EXM165-Patient/Condition/neg-denom-condition.json
@@ -1,0 +1,56 @@
+{
+  "resourceType": "Condition",
+  "id": "neg-denom-EXM165-Condition",
+  "clinicalStatus": {
+      "coding": [
+      {
+          "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+          "code": "active",
+          "display": "Active"
+      }
+      ],
+      "text": "Active"
+  },
+  "verificationStatus": {
+      "coding": [
+      {
+          "system": "http://terminology.hl7.org/CodeSystem/condition-verification",
+          "code": "confirmed",
+          "display": "confirmed"
+      }
+      ],
+      "text": "confirmed"
+  },
+  "severity": {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "6736007",
+          "display": "Moderate"
+        }
+      ],
+      "text": "Moderate"
+   },
+  "code": {
+      "coding": [
+      {
+          "system": "http://hl7.org/fhir/sid/icd-10-cm",
+          "code": "I10",
+          "display": "Essential (primary) hypertension"
+      }
+      ],
+      "text": "Essential (primary) Hypertention"
+  },
+  "subject": {
+      "reference": "Patient/neg-denom-EXM165-Patient"
+  },
+  "encounter": {
+      "reference": "Encounter/neg-denom-EXM165-Encounter"
+  },
+  "onsetPeriod": {
+      "start": "2019-01-16T08:30:00"
+  },
+  "abatementDateTime": "2019-01-20T08:30:00"
+
+
+}

--- a/input/tests/measure/ControllingHighBloodPressureFHIR/neg-denom-EXM165-Patient/Encounter/neg-denom-encounter.json
+++ b/input/tests/measure/ControllingHighBloodPressureFHIR/neg-denom-EXM165-Patient/Encounter/neg-denom-encounter.json
@@ -1,0 +1,24 @@
+{
+  "resourceType" : "Encounter",
+  "id": "neg-denom-EXM165-Encounter",
+  "status" : "finished",
+  "type" : [
+  {
+      "coding" : [
+      {
+          "system" : "http://www.ama-assn.org/go/cpt",
+          "code" : "99202",
+          "display" : "Office or other outpatient visit for the evaluation and management of a new patient, which requires a medically appropriate history and/or examination and straightforward medical decision making. When using time for code selection, 15-29 minutes of total time is spent on the date of the encounter."
+      }
+      ],
+      "text" : "Office Visit"
+  }
+  ],
+  "subject" : {
+  "reference" : "Patient/neg-denom-EXM165-Patient"
+  },
+  "period" : {
+  "start" : "2019-01-16T08:30:00",
+  "end" : "2019-01-20T08:30:00"
+  }
+}

--- a/input/tests/measure/ControllingHighBloodPressureFHIR/neg-denom-EXM165-Patient/Patient/neg-denom-patient.json
+++ b/input/tests/measure/ControllingHighBloodPressureFHIR/neg-denom-EXM165-Patient/Patient/neg-denom-patient.json
@@ -1,0 +1,45 @@
+{
+  "resourceType": "Patient",
+  "id": "neg-denom-EXM165-Patient",
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2106-3",
+            "display": "White"
+          }
+        }
+      ]
+    },
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2186-5",
+            "display": "Not Hispanic/Latino"
+          }
+        }
+      ]
+    }
+  ],
+  "active": true,
+  "name": [
+  {
+      "use": "official",
+      "text": "BECK,TOM",
+      "family": "BECK",
+      "given": [
+      "TOM"
+      ]
+  }
+  ],
+  "gender": "male",
+  "birthDate": "2015-06-30"
+}

--- a/input/tests/measure/ControllingHighBloodPressureFHIR/neg-numer-EXM165-Patient/Condition/neg-numer-condition.json
+++ b/input/tests/measure/ControllingHighBloodPressureFHIR/neg-numer-EXM165-Patient/Condition/neg-numer-condition.json
@@ -1,0 +1,53 @@
+{
+  "resourceType": "Condition",
+  "id": "neg-numer-EXM165-Condition",
+  "clinicalStatus": {
+      "coding": [
+      {
+          "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+          "code": "active",
+          "display": "Active"
+      }
+      ],
+      "text": "Active"
+  },
+  "verificationStatus": {
+      "coding": [
+      {
+          "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+          "code": "confirmed",
+          "display": "Confirmed"
+      }
+      ],
+      "text": "Confirmed"
+  },
+  "severity": {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "6736007",
+          "display": "Moderate"
+        }
+      ],
+      "text": "Moderate"
+    },
+  "code": {
+      "coding": [
+      {
+          "system": "http://hl7.org/fhir/sid/icd-10-cm",
+          "code": "I10",
+          "display": "Hypertention"
+      }
+      ],
+      "text": "Hypertention"
+  },
+  "subject": {
+      "reference": "Patient/neg-numer-EXM165-Patient"
+  },
+  "encounter": {
+      "reference": "Encounter/neg-numer-EXM165-Encounter"
+  },
+  "onsetPeriod": {
+      "start": "2009-01-16T08:30:00"
+  }
+}

--- a/input/tests/measure/ControllingHighBloodPressureFHIR/neg-numer-EXM165-Patient/Encounter/neg-numer-encounter.json
+++ b/input/tests/measure/ControllingHighBloodPressureFHIR/neg-numer-EXM165-Patient/Encounter/neg-numer-encounter.json
@@ -1,0 +1,32 @@
+{
+  "resourceType" : "Encounter",
+  "id": "neg-numer-EXM165-Encounter",
+  "text" : {
+  "status" : "generated"
+  },
+  "status" : "finished",
+  "class": {
+    "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+    "code": "AMB",
+    "display": "ambulatory"
+  },
+  "type" : [
+  {
+      "coding" : [
+      {
+          "system" : "urn:oid:2.16.840.1.113883.6.12",
+          "code" : "99201",
+          "display" : "Office Visit"
+      }
+      ],
+      "text" : "Office Visit"
+  }
+  ],
+  "subject" : {
+  "reference" : "Patient/neg-numer-EXM165-Patient"
+  },
+  "period" : {
+  "start" : "2019-01-16T08:30:00",
+  "end" : "2019-01-20T08:30:00"
+  }
+}

--- a/input/tests/measure/ControllingHighBloodPressureFHIR/neg-numer-EXM165-Patient/Observation/neg-numer-Observation.json
+++ b/input/tests/measure/ControllingHighBloodPressureFHIR/neg-numer-EXM165-Patient/Observation/neg-numer-Observation.json
@@ -1,0 +1,68 @@
+{
+  "resourceType": "Observation",
+  "id": "neg-numer-EXM165-Observation",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+    ]
+  },
+  "status": "final",
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+          "code": "vital-signs",
+          "display": "Vital Signs"
+        }
+      ]
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "85354-9",
+        "display": "Blood pressure panel with all children optional"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/neg-numer-EXM165-Patient"
+  },
+  "effectiveDateTime": "2019-01-17T12:30:00",
+  "encounter": {
+    "reference": "Encounter/neg-numer-EXM165-Encounter"
+  },
+  "interpretation": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+          "code": "L",
+          "display": "low"
+        }
+      ],
+      "text": "Below low normal"
+    }
+  ],
+  "component": [
+    {
+      "code": {
+        "coding": [
+          {
+            "system": "http://loinc.org",
+            "code": "8462-4",
+            "display": "Diastolic blood pressure"
+          }
+        ]
+      },
+      "valueQuantity": {
+        "value": 80,
+        "unit": "mm[Hg]",
+        "system": "http://unitsofmeasure.org",
+        "code": "mm[Hg]"
+      }
+    }
+  ]
+}

--- a/input/tests/measure/ControllingHighBloodPressureFHIR/neg-numer-EXM165-Patient/Observation/neg-numer-ObservationSystolic.json
+++ b/input/tests/measure/ControllingHighBloodPressureFHIR/neg-numer-EXM165-Patient/Observation/neg-numer-ObservationSystolic.json
@@ -1,0 +1,68 @@
+{
+  "resourceType": "Observation",
+  "id": "neg-numer-EXM165-ObservationSystolic",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+    ]
+  },
+  "status": "final",
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+          "code": "vital-signs",
+          "display": "Vital Signs"
+        }
+      ]
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "85354-9",
+        "display": "Blood pressure panel with all children optional"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/neg-numer-EXM165-Patient"
+  },
+  "effectiveDateTime": "2019-01-17T12:30:00",
+  "encounter": {
+    "reference": "Encounter/neg-numer-EXM165-Encounter"
+  },
+  "interpretation": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+          "code": "L",
+          "display": "low"
+        }
+      ],
+      "text": "Below low normal"
+    }
+  ],
+  "component": [
+    {
+      "code": {
+        "coding": [
+          {
+            "system": "http://loinc.org",
+            "code": "8480-6",
+            "display": "Systolic blood pressure"
+          }
+        ]
+      },
+      "valueQuantity": {
+        "value": 120,
+        "unit": "mm[Hg]",
+        "system": "http://unitsofmeasure.org",
+        "code": "mm[Hg]"
+      }
+    }
+  ]
+}

--- a/input/tests/measure/ControllingHighBloodPressureFHIR/neg-numer-EXM165-Patient/Patient/neg-numer-patient.json
+++ b/input/tests/measure/ControllingHighBloodPressureFHIR/neg-numer-EXM165-Patient/Patient/neg-numer-patient.json
@@ -1,0 +1,48 @@
+{
+  "resourceType": "Patient",
+  "id": "neg-numer-EXM165-Patient",
+  "text": {
+      "status": "extensions"
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2106-3",
+            "display": "White"
+          }
+        }
+      ]
+    },
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2135-2",
+            "display": "Hispanic or Latino"
+          }
+        }
+      ]
+    }
+  ],
+  "active": true,
+  "name": [
+  {
+      "use": "official",
+      "text": "BECK,TOM",
+      "family": "BECK",
+      "given": [
+      "TOM"
+      ]
+  }
+  ],
+  "gender": "male",
+  "birthDate": "2015-06-30"
+}


### PR DESCRIPTION
Added negative Test Cases to get Initial Population as FALSE for the following measures: 
1. CMS 125 - BreastCancerScreeningFHIR
2. CMS 111- Median Admit Decision Time to ED Departure Time for Admitted Patients
3. CMS 124- CervicalCancerScreening
4. CMS 153-ChlamydiaScreening 
5. CMS 165- ControllingHighBloodPressure
6. CMS 130- ColorectalCancerScreening 