### PR TITLE
Update updateCQFTooling and refresh scripts to use the latest version of CQF Tooling

### DIFF
--- a/_refresh.bat
+++ b/_refresh.bat
@@ -13,7 +13,7 @@ ECHO   -u  Unattended mode.  Defaults to false.
 GOTO exit0
 
 :refresh
-SET tooling_jar=tooling-1.4.1-SNAPSHOT-jar-with-dependencies.jar
+SET tooling_jar=tooling-2.4.0-SNAPSHOT-jar-with-dependencies.jar
 SET input_cache_path=%~dp0input-cache
 SET ig_resource_path=%~dp0input\ecqm-content-r4.xml
 SET unattended=false

--- a/_refresh.sh
+++ b/_refresh.sh
@@ -16,7 +16,7 @@ HELP_USAGE
 	exit 0
 }
 
-tooling_jar=tooling-1.4.1-SNAPSHOT-jar-with-dependencies.jar
+tooling_jar=tooling-2.4.0-jar-with-dependencies.jar
 input_cache_path=./input-cache
 ig_resource_path=./input/ecqm-content-r4.xml
 unattended=false

--- a/_updateCQFTooling.bat
+++ b/_updateCQFTooling.bat
@@ -2,8 +2,8 @@
 REM Necessary for the prompting of 'create' and 'overwrite' variables as, without this, they will be expanded immediately to '' and promptig will have no effect.
 setlocal EnableDelayedExpansion
 
-SET "dlurl=https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=org.opencds.cqf&a=tooling&v=1.4.0&c=jar-with-dependencies"
-SET tooling_jar=tooling-1.4.0-jar-with-dependencies.jar
+SET "dlurl=https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=org.opencds.cqf&a=tooling-cli&v=2.4.0&c=jar-with-dependencies"
+SET tooling_jar=tooling-2.4.0-jar-with-dependencies.jar
 SET input_cache_path=%~dp0input-cache\
 SET skipPrompts=false
 IF "%~1"=="/f" SET skipPrompts=true

--- a/_updateCQFTooling.sh
+++ b/_updateCQFTooling.sh
@@ -4,16 +4,16 @@
 
 r=releases
 g=org.opencds.cqf
-a=tooling
-v=1.4.0
+a=tooling-cli
+v=2.4.0
 c=jar-with-dependencies
 
-dlurl='https://oss.sonatype.org/service/local/artifact/maven/redirect?r='${r}'&g='${g}'&a='${a}'&v='${v}'&c='${c}''
+dlurl='https://oss.sonatype.org/service/local/artifact/maven/redirect?r='${r}'&g='${g}'&a='${a}'&v='${v}''
 
 echo ${dlurl}
 
 input_cache_path=./input-cache/
-tooling_jar=tooling-1.4.0-jar-with-dependencies.jar
+tooling_jar=tooling-2.4.0-jar-with-dependencies.jar
 
 set -e
 if ! type "curl" > /dev/null; then


### PR DESCRIPTION
Updating version of cqf-tooling jar to 2.4.0 (latest) to resolve an open issue reported in cqf-tooling repository.

https://github.com/cqframework/cqf-tooling/issues/317

Updating this resolves the issue of duplicate entries in dataRequirement element of Library resource